### PR TITLE
BUG: _save_model_after_aggregation flag in FlwrFederatedCallback unused

### DIFF
--- a/flwr_serverless/keras/federated_learning_callback.py
+++ b/flwr_serverless/keras/federated_learning_callback.py
@@ -113,6 +113,13 @@ class FlwrFederatedCallback(keras.callbacks.Callback):
             )
             self._save_model_to_shared_folder(filename)
 
+    def _save_model_after_aggregation(self, node_id, epoch):
+        if self.save_model_after_aggregation:
+            filename = self.model_after_aggregation_filename_pattern.format(
+                node_id=node_id, epoch=epoch
+            )
+            self._save_model_to_shared_folder(filename)
+            
     def on_epoch_end(self, epoch: int, logs=None):
         # use the P2PStrategy to update the model.
         node_id = self.node.node_id
@@ -144,12 +151,7 @@ class FlwrFederatedCallback(keras.callbacks.Callback):
         # Update the keras model and keras logs.
         if updated_params is not None:
             self.model.set_weights(parameters_to_ndarrays(updated_params))
-            if self.save_model_before_aggregation:
-                node_id = self.node.node_id
-                filename = self.model_before_aggregation_filename_pattern.format(
-                    node_id=node_id, epoch=epoch
-                )
-                self._save_model_to_shared_folder(filename)
+            self._save_model_after_aggregation(node_id, epoch)
             if updated_metrics is not None:
                 if self.override_metrics_with_aggregated_metrics:
                     logs.update(updated_metrics)


### PR DESCRIPTION
Theaim of this PR is to address a previously overlooked issue where the `_save_model_after_aggregation` flag within the `FlwrFederatedCallback` was not being utilized as intended in the callback's workflow. The oversight led to the potential for models that should be saved after aggregation, as per user configuration, to not be saved, thereby affecting the ability to monitor and evaluate model performance across different training epochs accurately.

To rectify this, the PR introduces changes that ensure the `_save_model_after_aggregation` flag's functionality is correctly implemented. Specifically, it adds a call to the _save_model_after_aggregation method within `on_epoch_end`, conditional on the flag's truth value. This ensures that after each training epoch, if the flag is set to True, the aggregated model is saved according to the specified filename pattern, and the model does not redundantly save before aggregation, as is apparently the case in the existing logic (i.e. at least for the 0.2.9 release)